### PR TITLE
GH-3: Add UDATE support for ingestQuery

### DIFF
--- a/cassandra-app-dependencies/pom.xml
+++ b/cassandra-app-dependencies/pom.xml
@@ -1,77 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.springframework.cloud.stream.app</groupId>
-    <artifactId>cassandra-app-dependencies</artifactId>
-    <version>1.1.2.BUILD-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <name>cassandra-app-dependencies</name>
-    <description>Spring Cloud Stream Cassandra App Dependencies</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.cloud.stream.app</groupId>
+	<artifactId>cassandra-app-dependencies</artifactId>
+	<version>1.1.2.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>cassandra-app-dependencies</name>
+	<description>Spring Cloud Stream Cassandra App Dependencies</description>
 
-    <parent>
-	<artifactId>spring-cloud-dependencies-parent</artifactId>
-        <groupId>org.springframework.cloud</groupId>
-        <version>1.2.1.RELEASE</version>
-        <relativePath />
-    </parent>
+	<parent>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>1.2.1.RELEASE</version>
+		<relativePath/>
+	</parent>
 
-    <properties>
-        <spring-integration-cassandra.version>0.5.0.RELEASE</spring-integration-cassandra.version>
-        <cassandra-all.version>2.1.5</cassandra-all.version>
-        <cassandra-unit-spring.version>2.1.9.2</cassandra-unit-spring.version>
-    </properties>
+	<properties>
+		<spring-integration-cassandra.version>0.5.0.RELEASE</spring-integration-cassandra.version>
+		<cassandra-unit-spring.version>2.2.2.1</cassandra-unit-spring.version>
+	</properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-sink-cassandra</artifactId>
-                <version>1.1.2.BUILD-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.integration</groupId>
-                <artifactId>spring-integration-cassandra</artifactId>
-                <version>${spring-integration-cassandra.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.cassandra</groupId>
-                <artifactId>cassandra-all</artifactId>
-                <version>${cassandra-all.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.cassandraunit</groupId>
-                <artifactId>cassandra-unit-spring</artifactId>
-                <version>${cassandra-unit-spring.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.cassandra</groupId>
-                        <artifactId>cassandra-all</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.datastax.cassandra</groupId>
-                        <artifactId>cassandra-driver-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-<profiles>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-sink-cassandra</artifactId>
+				<version>1.1.2.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.integration</groupId>
+				<artifactId>spring-integration-cassandra</artifactId>
+				<version>${spring-integration-cassandra.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.cassandraunit</groupId>
+				<artifactId>cassandra-unit-spring</artifactId>
+				<version>${cassandra-unit-spring.version}</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>cassandra-app-starters-build</artifactId>
 	<version>1.1.2.BUILD-SNAPSHOT</version>
@@ -27,7 +28,8 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-<profiles>
+
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-stream-sink-cassandra/pom.xml
+++ b/spring-cloud-starter-stream-sink-cassandra/pom.xml
@@ -19,8 +19,8 @@
 			<artifactId>spring-integration-cassandra</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.cassandra</groupId>
-			<artifactId>cassandra-all</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-cassandra</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.cassandraunit</groupId>
@@ -55,4 +55,5 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/query/ColumnNameExtractor.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/query/ColumnNameExtractor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.cassandra.query;
+
+import java.util.List;
+
+/**
+ * @author Akos Ratku
+ * @author Artem Bilan
+ */
+public interface ColumnNameExtractor {
+
+	List<String> extract(String query);
+
+}

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/query/InsertQueryColumnNameExtractor.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/query/InsertQueryColumnNameExtractor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.cassandra.query;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Akos Ratku
+ * @author Artem Bilan
+ */
+public class InsertQueryColumnNameExtractor implements ColumnNameExtractor {
+
+	private static final Pattern PATTERN = Pattern.compile(".+\\((.+)\\).+(?:values\\s*\\((.+)\\))");
+
+	@Override
+	public List<String> extract(String query) {
+		List<String> extractedColumns = new LinkedList<>();
+		Matcher matcher = PATTERN.matcher(query);
+		if (matcher.matches()) {
+			String[] columns = StringUtils.delimitedListToStringArray(matcher.group(1), ",", " ");
+			String[] params = StringUtils.delimitedListToStringArray(matcher.group(2), ",", " ");
+			for (int i = 0; i < columns.length; i++) {
+				String param = params[i];
+				if (param.equals("?")) {
+					extractedColumns.add(columns[i]);
+				}
+				else if (param.startsWith(":")) {
+					extractedColumns.add(param.substring(1));
+				}
+			}
+		}
+		else {
+			throw new IllegalArgumentException("Invalid CQL insert query syntax: " + query);
+		}
+		return extractedColumns;
+	}
+
+}

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/query/UpdateQueryColumnNameExtractor.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/query/UpdateQueryColumnNameExtractor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.cassandra.query;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Akos Ratku
+ * @author Artem Bilan
+ */
+public class UpdateQueryColumnNameExtractor implements ColumnNameExtractor {
+
+	private static final Pattern PATTERN = Pattern.compile("(?i)(?<=set)(.*)(?=where)where(.*)");
+
+	@Override
+	public List<String> extract(String query) {
+		List<String> extractedColumns = new LinkedList<>();
+		Matcher matcher = PATTERN.matcher(query);
+		if (matcher.find()) {
+			String[] settings = StringUtils.delimitedListToStringArray(matcher.group(1), ",", " ");
+			String[] where = StringUtils.delimitedListToStringArray(matcher.group(2), ",", " ");
+			readPairs(extractedColumns, settings);
+			readPairs(extractedColumns, where);
+		}
+		else {
+			throw new IllegalArgumentException("Invalid CQL update query syntax: " + query);
+		}
+		return extractedColumns;
+	}
+
+	protected void readPairs(List<String> extractedColumns, String[] settings) {
+		for (String setting : settings) {
+			String[] columnValuePair = StringUtils.delimitedListToStringArray(setting, "=", " ");
+			if (columnValuePair[1].startsWith(":") || columnValuePair[1].equals("?")) {
+				extractedColumns.add(columnValuePair[0]);
+			}
+		}
+	}
+
+}

--- a/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkPropertiesTests.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/test/java/org/springframework/cloud/stream/app/cassandra/sink/CassandraSinkPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.cassandra.core.ConsistencyLevel;
 import org.springframework.cassandra.core.RetryPolicy;
 import org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration;


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/cassandra#3 GH-3 (https://github.com/spring-cloud-stream-app-starters/cassandra/issues/3)

* Introduce `ColumnNameExtractor` abstraction and `InsertQueryColumnNameExtractor` and `UpdateQueryColumnNameExtractor` implementations
* Modify `PayloadToMatrixTransformer` to delegate to the `ColumnNameExtractor`
* Upgrade to Cassandra 2.2.2 for testing
* Resolve deprecations according Spring Boot upgrade
* Leave most of test as `@Ignored` because it looks like Embedded Cassandra race condition hasn't been fixed yet.
Looks like we should consider testing against real Cassandra, e.g. on the CI server