### PR TITLE
add --useSsl=true|false and --skipSslValidation=true|false

### DIFF
--- a/spring-cloud-starter-stream-sink-cassandra/README.adoc
+++ b/spring-cloud-starter-stream-sink-cassandra/README.adoc
@@ -18,9 +18,9 @@ $$cassandra.cluster.metrics-enabled$$:: $$Enable/disable metrics collection for 
 $$cassandra.cluster.password$$:: $$The password for connection.$$ *($$String$$, default: `$$<none>$$`)*
 $$cassandra.cluster.port$$:: $$The port to use to connect to the Cassandra host.$$ *($$Integer$$, default: `$$<none>$$`)*
 $$cassandra.cluster.schema-action$$:: $$The schema action to perform.$$ *($$SchemaAction$$, default: `$$<none>$$`, possible values: `NONE`,`CREATE`,`CREATE_IF_NOT_EXISTS`,`RECREATE`,`RECREATE_DROP_UNUSED`)*
+$$cassandra.cluster.skip-ssl-validation$$:: $$The flag to validate the Servers' SSL certs$$ *($$Boolean$$, default: `$$false$$`)*
 $$cassandra.cluster.use-ssl$$:: $$The flag to use SSL to connect$$ *($$Boolean$$, default: `$$false$$`)*
 $$cassandra.cluster.username$$:: $$The username for connection.$$ *($$String$$, default: `$$<none>$$`)*
-$$cassandra.cluster.validate-ssl$$:: $$The flag to validate the Servers' SSL certs$$ *($$Boolean$$, default: `$$true$$`)*
 $$cassandra.consistency-level$$:: $$The consistencyLevel option of WriteOptions.$$ *($$ConsistencyLevel$$, default: `$$<none>$$`, possible values: `ANY`,`ONE`,`TWO`,`THREE`,`QUOROM`,`LOCAL_QUOROM`,`EACH_QUOROM`,`ALL`,`LOCAL_ONE`,`SERIAL`,`LOCAL_SERIAL`,`QUORUM`,`LOCAL_QUORUM`,`EACH_QUORUM`)*
 $$cassandra.ingest-query$$:: $$The ingest Cassandra query.$$ *($$String$$, default: `$$<none>$$`)*
 $$cassandra.query-type$$:: $$The queryType for Cassandra Sink.$$ *($$Type$$, default: `$$<none>$$`, possible values: `INSERT`,`UPDATE`,`DELETE`,`STATEMENT`)*

--- a/spring-cloud-starter-stream-sink-cassandra/README.adoc
+++ b/spring-cloud-starter-stream-sink-cassandra/README.adoc
@@ -8,7 +8,7 @@ This sink application writes the content of each message it receives into Cassan
 The **$$cassandra$$** $$sink$$ has the following options:
 
 //tag::configuration-properties[]
-$$cassandra.cluster.compression-type$$:: $$The compression to use for the transport.$$ *($$CompressionType$$, default: `$$<none>$$`, possible values: `NONE`,`SNAPPY`)*
+$$cassandra.cluster.compression-type$$:: $$The compression to use for the transport.$$ *($$CompressionType$$, default: `$$<none>$$`, possible values: `NONE`,`SNAPPY`,`LZ4`)*
 $$cassandra.cluster.contact-points$$:: $$The comma-delimited string of the hosts to connect to Cassandra.$$ *($$String$$, default: `$$<none>$$`)*
 $$cassandra.cluster.create-keyspace$$:: $$The flag to create (or not) keyspace on application startup.$$ *($$Boolean$$, default: `$$false$$`)*
 $$cassandra.cluster.entity-base-packages$$:: $$The base packages to scan for entities annotated with Table annotations.$$ *($$String[]$$, default: `$$[]$$`)*
@@ -17,11 +17,13 @@ $$cassandra.cluster.keyspace$$:: $$The keyspace name to connect to.$$ *($$String
 $$cassandra.cluster.metrics-enabled$$:: $$Enable/disable metrics collection for the created cluster.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$cassandra.cluster.password$$:: $$The password for connection.$$ *($$String$$, default: `$$<none>$$`)*
 $$cassandra.cluster.port$$:: $$The port to use to connect to the Cassandra host.$$ *($$Integer$$, default: `$$<none>$$`)*
-$$cassandra.cluster.schema-action$$:: $$The schema action to perform.$$ *($$SchemaAction$$, default: `$$<none>$$`, possible values: `NONE`,`CREATE`,`RECREATE`,`RECREATE_DROP_UNUSED`)*
+$$cassandra.cluster.schema-action$$:: $$The schema action to perform.$$ *($$SchemaAction$$, default: `$$<none>$$`, possible values: `NONE`,`CREATE`,`CREATE_IF_NOT_EXISTS`,`RECREATE`,`RECREATE_DROP_UNUSED`)*
+$$cassandra.cluster.use-ssl$$:: $$The flag to use SSL to connect$$ *($$Boolean$$, default: `$$false$$`)*
 $$cassandra.cluster.username$$:: $$The username for connection.$$ *($$String$$, default: `$$<none>$$`)*
-$$cassandra.consistency-level$$:: $$The consistencyLevel option of WriteOptions.$$ *($$ConsistencyLevel$$, default: `$$<none>$$`, possible values: `ANY`,`ONE`,`TWO`,`THREE`,`QUOROM`,`LOCAL_QUOROM`,`EACH_QUOROM`,`ALL`,`LOCAL_ONE`,`SERIAL`,`LOCAL_SERIAL`)*
+$$cassandra.cluster.validate-ssl$$:: $$The flag to validate the Servers' SSL certs$$ *($$Boolean$$, default: `$$true$$`)*
+$$cassandra.consistency-level$$:: $$The consistencyLevel option of WriteOptions.$$ *($$ConsistencyLevel$$, default: `$$<none>$$`, possible values: `ANY`,`ONE`,`TWO`,`THREE`,`QUOROM`,`LOCAL_QUOROM`,`EACH_QUOROM`,`ALL`,`LOCAL_ONE`,`SERIAL`,`LOCAL_SERIAL`,`QUORUM`,`LOCAL_QUORUM`,`EACH_QUORUM`)*
 $$cassandra.ingest-query$$:: $$The ingest Cassandra query.$$ *($$String$$, default: `$$<none>$$`)*
-$$cassandra.query-type$$:: $$The queryType for Cassandra Sink.$$ *($$org.springframework.integration.cassandra.outbound.CassandraMessageHandler<T>$Type$$, default: `$$<none>$$`)*
+$$cassandra.query-type$$:: $$The queryType for Cassandra Sink.$$ *($$Type$$, default: `$$<none>$$`, possible values: `INSERT`,`UPDATE`,`DELETE`,`STATEMENT`)*
 $$cassandra.retry-policy$$:: $$The retryPolicy option of WriteOptions.$$ *($$RetryPolicy$$, default: `$$<none>$$`, possible values: `DEFAULT`,`DOWNGRADING_CONSISTENCY`,`FALLTHROUGH`,`LOGGING`)*
 $$cassandra.statement-expression$$:: $$The expression in Cassandra query DSL style.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$cassandra.ttl$$:: $$The time-to-live option of WriteOptions.$$ *($$Integer$$, default: `$$0$$`)*

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraConfiguration.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraConfiguration.java
@@ -16,14 +16,14 @@
 
 package org.springframework.cloud.stream.app.cassandra;
 
-import com.datastax.driver.core.AuthProvider;
-import com.datastax.driver.core.PlainTextAuthProvider;
-import com.datastax.driver.core.Session;
+import com.datastax.driver.core.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cassandra.config.ClusterBuilderConfigurer;
 import org.springframework.cassandra.config.CompressionType;
 import org.springframework.cassandra.core.CqlTemplate;
 import org.springframework.cassandra.core.keyspace.CreateKeyspaceSpecification;
+import org.springframework.cloud.stream.app.cassandra.util.NonValidatingSSLContextFactory;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.cassandra.config.SchemaAction;
 import org.springframework.data.cassandra.config.java.AbstractCassandraConfiguration;
@@ -104,6 +104,24 @@ public class CassandraConfiguration extends AbstractCassandraConfiguration {
 		}
 	}
 
+	@Override
+	protected ClusterBuilderConfigurer getClusterBuilderConfigurer() {
+		return new ClusterBuilderConfigurer() {
+			@Override
+			public Cluster.Builder configure(Cluster.Builder clusterBuilder) {
+				if(cassandraProperties.isUseSsl()) {
+					JdkSSLOptions.Builder optsBuilder = JdkSSLOptions.builder();
+					if(!cassandraProperties.isValidateSsl()) {
+						optsBuilder.withSSLContext(NonValidatingSSLContextFactory.getSslContext());
+					}
+					return clusterBuilder.withSSL(optsBuilder.build());
+				}
+				else {
+					return clusterBuilder;
+				}
+			}
+		};
+	}
 	/**
 	 * Inner class to execute init scripts on the provided {@code keyspace}.
 	 * It is here to bypass circular dependency with {@link Session} injection and

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraConfiguration.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraConfiguration.java
@@ -111,7 +111,7 @@ public class CassandraConfiguration extends AbstractCassandraConfiguration {
 			public Cluster.Builder configure(Cluster.Builder clusterBuilder) {
 				if(cassandraProperties.isUseSsl()) {
 					JdkSSLOptions.Builder optsBuilder = JdkSSLOptions.builder();
-					if(!cassandraProperties.isValidateSsl()) {
+					if(cassandraProperties.isSkipSslValidation()) {
 						optsBuilder.withSSLContext(NonValidatingSSLContextFactory.getSslContext());
 					}
 					return clusterBuilder.withSSL(optsBuilder.build());

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
@@ -100,7 +100,7 @@ public class CassandraProperties {
 	 * The flag to validate the Servers' SSL certs
 	 */
 
-	private boolean skipSslValidation = true;
+	private boolean skipSslValidation = false;
 
 	/**
 	 * Enable/disable metrics collection for the created cluster.

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
@@ -35,6 +35,7 @@ import org.springframework.validation.annotation.Validated;
  *
  * @author Artem Bilan
  * @author Thomas Risberg
+ * @author Rob Hardt
  */
 @ConfigurationProperties("cassandra.cluster")
 @Validated
@@ -147,9 +148,9 @@ public class CassandraProperties {
 		this.metricsEnabled = metricsEnabled;
 	}
 
-	public void setUseSsl(boolean useSsl) { this.useSsl = useSsl; }
+	public void setUseSsl(boolean useSsl) { this.useSsl = this.useSsl; }
 
-	public void setSkipSslValidation(boolean skipSslValidation) { this.skipSslValidation = skipSslValidation; }
+	public void setSkipSslValidation(boolean skipSslValidation) { this.skipSslValidation = this.skipSslValidation; }
 
 	@NotNull
 	public String getContactPoints() {
@@ -203,9 +204,9 @@ public class CassandraProperties {
 		return this.metricsEnabled;
 	}
 
-	public boolean isUseSsl() { return useSsl; }
+	public boolean isUseSsl() { return this.useSsl; }
 
-	public boolean isSkipSslValidation() { return skipSslValidation; }
+	public boolean isSkipSslValidation() { return this.skipSslValidation; }
 
 	@AssertFalse(message = "both 'username' and 'password' are required or neither one")
 	private boolean isInvalid() {

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
@@ -100,7 +100,7 @@ public class CassandraProperties {
 	 * The flag to validate the Servers' SSL certs
 	 */
 
-	private boolean validateSsl = true;
+	private boolean skipSslValidation = true;
 
 	/**
 	 * Enable/disable metrics collection for the created cluster.
@@ -149,8 +149,7 @@ public class CassandraProperties {
 
 	public void setUseSsl(boolean useSsl) { this.useSsl = useSsl; }
 
-	public void setValidateSsl(boolean validateSsl) { this.validateSsl = validateSsl; }
-
+	public void setSkipSslValidation(boolean skipSslValidation) { this.skipSslValidation = skipSslValidation; }
 
 	@NotNull
 	public String getContactPoints() {
@@ -206,10 +205,7 @@ public class CassandraProperties {
 
 	public boolean isUseSsl() { return useSsl; }
 
-	public boolean isValidateSsl() { return validateSsl; }
-
-
-
+	public boolean isSkipSslValidation() { return skipSslValidation; }
 
 	@AssertFalse(message = "both 'username' and 'password' are required or neither one")
 	private boolean isInvalid() {

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/CassandraProperties.java
@@ -92,6 +92,17 @@ public class CassandraProperties {
 	private CompressionType compressionType = CompressionType.NONE;
 
 	/**
+	 * The flag to use SSL to connect
+	 */
+	private boolean useSsl;
+
+	/**
+	 * The flag to validate the Servers' SSL certs
+	 */
+
+	private boolean validateSsl = true;
+
+	/**
 	 * Enable/disable metrics collection for the created cluster.
 	 */
 	private boolean metricsEnabled = CassandraCqlClusterFactoryBean.DEFAULT_METRICS_ENABLED;
@@ -135,6 +146,11 @@ public class CassandraProperties {
 	public void setMetricsEnabled(boolean metricsEnabled) {
 		this.metricsEnabled = metricsEnabled;
 	}
+
+	public void setUseSsl(boolean useSsl) { this.useSsl = useSsl; }
+
+	public void setValidateSsl(boolean validateSsl) { this.validateSsl = validateSsl; }
+
 
 	@NotNull
 	public String getContactPoints() {
@@ -187,6 +203,13 @@ public class CassandraProperties {
 	public boolean isMetricsEnabled() {
 		return this.metricsEnabled;
 	}
+
+	public boolean isUseSsl() { return useSsl; }
+
+	public boolean isValidateSsl() { return validateSsl; }
+
+
+
 
 	@AssertFalse(message = "both 'username' and 'password' are required or neither one")
 	private boolean isInvalid() {

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/util/NonValidatingSSLContextFactory.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/util/NonValidatingSSLContextFactory.java
@@ -1,12 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.stream.app.cassandra.util;
 
 import javax.net.ssl.*;
 import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
+
+/**
+ * Helper to provide an SSL Context that does not validate
+ * certificates presented in the SSL handshake.
+ *
+ * The usual caveats apply.
+ *
+ * @author Rob Hardt
+ */
 public class NonValidatingSSLContextFactory {
-    public static SSLContext getSslContext() {
+    public static SSLContext getSslContext() throws NoSuchAlgorithmException,
+            KeyManagementException{
 
         TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
             public X509Certificate[] getAcceptedIssuers() {
@@ -20,12 +48,8 @@ public class NonValidatingSSLContextFactory {
             }
         } };
 
-        SSLContext sc = null;
-        try {
-            sc = SSLContext.getInstance("SSL");
-            sc.init(null, trustAllCerts, new SecureRandom());
-        } catch (GeneralSecurityException e) {
-        }
+        SSLContext sc = SSLContext.getInstance("SSL");
+        sc.init(null, trustAllCerts, new SecureRandom());
         return sc;
     }
 

--- a/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/util/NonValidatingSSLContextFactory.java
+++ b/spring-cloud-starter-stream-sink-cassandra/src/main/java/org/springframework/cloud/stream/app/cassandra/util/NonValidatingSSLContextFactory.java
@@ -1,0 +1,32 @@
+package org.springframework.cloud.stream.app.cassandra.util;
+
+import javax.net.ssl.*;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+public class NonValidatingSSLContextFactory {
+    public static SSLContext getSslContext() {
+
+        TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+
+            public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+            }
+
+            public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+            }
+        } };
+
+        SSLContext sc = null;
+        try {
+            sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCerts, new SecureRandom());
+        } catch (GeneralSecurityException e) {
+        }
+        return sc;
+    }
+
+}


### PR DESCRIPTION
enable the Cassandra sink to connect to Cassandra clusters that have enabled SSL for incoming native transport connections.  

Fixes spring-cloud-stream-app-starters/cassandra#5